### PR TITLE
BAM-143: get spec head commit tag to drive the build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,32 +1,30 @@
 name: Build
 
 on:
-  repository_dispatch:
-    types: [ tag-push ]
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'source tag'
-        required: true
-        type: string
 
 jobs:
   tagging:
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ env.tag }}
-      version: ${{ env.version }}
-      prerelease: ${{ env.prerelease }}
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+      prerelease: ${{ steps.tag.outputs.prerelease }}
     steps:
-      - name: Use the tag from the event
+      - name: Fetch head tag from kp-protocols-clientsdk
         id: tag
         run: |
-          TAG="${{ inputs.tag || github.event.client_payload.tag }}"
-          VERSION=${TAG#v}
-          echo "TAG from event: ${TAG}"
-          echo "tag=${TAG}" >> $GITHUB_ENV
-          echo "version=${VERSION}">> $GITHUB_ENV
-          if [[ "${TAG}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_ENV; else echo "prerelease=false" >> $GITHUB_ENV; fi
+          git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+          cd proto-repo
+          head_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
+          if [[ -z "${head_tag}" ]]; then
+            echo "No tag found on the head commit of kp-protocols-clientsdk repo. Failing the action."
+            exit 1
+          else
+            echo "tag=${head_tag}" >> $GITHUB_OUTPUT
+            echo "version=${head_tag#v}" >> $GITHUB_OUTPUT
+            if [[ "${head_tag}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
+          fi
 
   build-python-3_6:
     needs:
@@ -94,7 +92,7 @@ jobs:
           python-version: '3.12.6'
       - name: Upgrade python tools
         run: python -m pip install --upgrade pip build setuptools wheel
-      - name: Install twinte for publishing
+      - name: Install twine for publishing
         run: python -m pip install twine
       - name: Install Requirements
         run: python -m pip install -r versions/3_12/requirements.txt


### PR DESCRIPTION
**What has changed**

1. Dispatch from protocols repo is to be removed, so we remove the trigger rely on it.
2. Tags now to be acquired from the head commit of public protobuf spec repo (kp-protocols-clientsdk).
3. Build will fail if the head commit contains no tag.

**Reason**

1. This approach avoids privilege issues as public repositories (e.g., protobuf specs) can be accessed by private repositories without requiring special tokens or permissions.
2. It provides manual control over each SDK’s release, ensuring readiness (e.g., documentation and examples) before public release.
