### PR TITLE
Task/bam 161 release from an input tag in anywhere

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,7 @@ on:
         description: 'Optional tag for kp-protocols-clientsdk'
         required: false
         default: ''
+
 jobs:
   tagging:
     runs-on: ubuntu-latest
@@ -49,8 +50,7 @@ jobs:
         run: python -m pip install --upgrade pip build setuptools wheel
       - name: Install Requirements
         run: python -m pip install -r versions/3_6/requirements.txt
-      - &clone-proto-repo
-        name: Clone Proto Repo
+      - name: Clone Proto Repo
         run: |
           git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
           cd proto-repo || { echo "Failed to change directory to proto-repo"; exit 1; }
@@ -109,7 +109,12 @@ jobs:
         run: python -m pip install twine
       - name: Install Requirements
         run: python -m pip install -r versions/3_12/requirements.txt
-      - *clone-proto-repo
+      - name: Clone Proto Repo
+        run: |
+          git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+          cd proto-repo || { echo "Failed to change directory to proto-repo"; exit 1; }
+          git checkout tags/${{ needs.tagging.outputs.tag }} -b temp-branch || { echo "Failed to checkout tag ${{ needs.tagging.outputs.tag }}"; exit 1; }
+          cd ..
       - name: Move Proto Folder
         run: |
           cp -R kp-protocols-clientsdk/src/main/proto versions/3_12/proto

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,11 @@ name: Build
 
 on:
   workflow_dispatch:
-
+    inputs:
+      kp_tag:
+        description: 'Optional tag for kp-protocols-clientsdk'
+        required: false
+        default: ''
 jobs:
   tagging:
     runs-on: ubuntu-latest
@@ -11,19 +15,23 @@ jobs:
       version: ${{ steps.tag.outputs.version }}
       prerelease: ${{ steps.tag.outputs.prerelease }}
     steps:
-      - name: Fetch head tag from kp-protocols-clientsdk
+      - name: Determine version tag from kp-protocols-clientsdk
         id: tag
         run: |
-          git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
-          cd proto-repo
-          head_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
-          if [[ -z "${head_tag}" ]]; then
+          if [ -n "${{ github.event.inputs.kp_tag }}" ]; then
+             version_tag=${{ github.event.inputs.kp_tag }}
+          else
+            git clone --branch main https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+            cd proto-repo
+            version_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
+          fi
+          if [[ -z "${version_tag}" ]]; then
             echo "No tag found on the head commit of kp-protocols-clientsdk repo. Failing the action."
             exit 1
           else
-            echo "tag=${head_tag}" >> $GITHUB_OUTPUT
-            echo "version=${head_tag#v}" >> $GITHUB_OUTPUT
-            if [[ "${head_tag}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
+            echo "tag=${version_tag}" >> $GITHUB_OUTPUT
+            echo "version=${version_tag#v}" >> $GITHUB_OUTPUT
+            if [[ "${version_tag}" == *-* ]]; then echo "prerelease=true" >> $GITHUB_OUTPUT; else echo "prerelease=false" >> $GITHUB_OUTPUT; fi
           fi
 
   build-python-3_6:
@@ -41,8 +49,13 @@ jobs:
         run: python -m pip install --upgrade pip build setuptools wheel
       - name: Install Requirements
         run: python -m pip install -r versions/3_6/requirements.txt
-      - name: Clone Proto Repo
-        run: git clone https://github.com/KodyPay/kp-protocols-clientsdk.git
+      - &clone-proto-repo
+        name: Clone Proto Repo
+        run: |
+          git clone https://github.com/KodyPay/kp-protocols-clientsdk.git proto-repo
+          cd proto-repo || { echo "Failed to change directory to proto-repo"; exit 1; }
+          git checkout tags/${{ needs.tagging.outputs.tag }} -b temp-branch || { echo "Failed to checkout tag ${{ needs.tagging.outputs.tag }}"; exit 1; }
+          cd ..
       - name: Move Proto Folder
         run: |
           cp -R kp-protocols-clientsdk/src/main/proto versions/3_6/proto
@@ -96,8 +109,7 @@ jobs:
         run: python -m pip install twine
       - name: Install Requirements
         run: python -m pip install -r versions/3_12/requirements.txt
-      - name: Clone Proto Repo
-        run: git clone https://github.com/KodyPay/kp-protocols-clientsdk.git
+      - *clone-proto-repo
       - name: Move Proto Folder
         run: |
           cp -R kp-protocols-clientsdk/src/main/proto versions/3_12/proto

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,8 +58,8 @@ jobs:
           cd ..
       - name: Move Proto Folder
         run: |
-          cp -R kp-protocols-clientsdk/src/main/proto versions/3_6/proto
-          rm -rf kp-protocols-clientsdk
+          cp -R proto-repo/src/main/proto versions/3_6/proto
+          rm -rf proto-repo
       - name: Generate GRPC Sources
         run: |
           cd versions/3_6
@@ -117,8 +117,8 @@ jobs:
           cd ..
       - name: Move Proto Folder
         run: |
-          cp -R kp-protocols-clientsdk/src/main/proto versions/3_12/proto
-          rm -rf kp-protocols-clientsdk
+          cp -R proto-repo/src/main/proto versions/3_12/proto
+          rm -rf proto-repo
       - name: Generate GRPC Sources
         run: |
           cd versions/3_12


### PR DESCRIPTION
**Associated JIRA tasks**

BAM-161

**What does the change do?**

For a new project, we may want to release an SDK with an alpha(prerelease) version of our specification to our customers to gather early feedback. The alpha version of the specification might still be under review and reside in a task or feature branch.
Additionally, for developers, it can be beneficial to release a prerelease version of the SDK. This allows them to begin working on a specification that hasn’t been fully finalized, especially in situations requiring urgent progress.
**What has been changed**

To be able to release the such sdk from an alpha version spec, the action from the sdk repo need to checkout the protobuf spec using a manual input tag.
Also included new spec to be published for user to try

**Tests**
Run from task branch being successful

https://github.com/KodyPay/kody-clientsdk-python/actions/runs/12831980803